### PR TITLE
Updates to state.py

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ classifiers =
 
 [options]
 # The package names (import):
-python_requires = ~=3.11
+python_requires = ~=3.10
 # You don't need package_dir if your packeges are at the top.
 package_dir =
     =src

--- a/src/mftscleanup/state.py
+++ b/src/mftscleanup/state.py
@@ -38,9 +38,13 @@ STATE_NAMES = [s.name for s in State]
 
 def get_transition(
     current_state: State, current_state_start_date: date
-) -> tuple[State, date] | tuple[None, None]:
+) -> tuple[State, date | None]:
+    """
+    Return the next state and the date of transition to that new state. Return
+    None for date if the next state is the current state.
+    """
     if current_state in (State.CLEANUP, State.HOLD):
-        return None, None
+        return current_state, None
 
     if current_state == State.INITIAL:
         number_of_business_days = 15
@@ -54,8 +58,7 @@ def get_transition(
         assert False, (current_state, current_state_start_date)
 
     new_date = add_business_days(current_state_start_date, number_of_business_days)
-    assert new_date is not None, (current_state, current_state_start_date)
     new_state = current_state.next
-    assert new_state is not None
+    assert new_state is not None, (current_state, current_state_start_date)
 
     return new_state, new_date

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -59,13 +59,13 @@ def test_state_next_property():
         "FIRST_EMAIL   2020-01-23  SECOND_EMAIL 2020-01-28",
         "SECOND_EMAIL  2020-01-28  FINAL_EMAIL  2020-01-29",
         "FINAL_EMAIL   2020-01-29  CLEANUP      2020-01-30",
-        "CLEANUP       2020-01-30  None         None",
+        "CLEANUP       2020-01-30  CLEANUP         None",
         # Test cases for a share that missed all holidays:
         "INITIAL       2020-08-03  FIRST_EMAIL  2020-08-24",
         "FIRST_EMAIL   2020-08-24  SECOND_EMAIL 2020-08-27",
         "SECOND_EMAIL  2020-08-27  FINAL_EMAIL  2020-08-28",
         "FINAL_EMAIL   2020-08-28  CLEANUP      2020-08-31",
-        "CLEANUP       2020-08-31  None         None",
+        "CLEANUP       2020-08-31  CLEANUP         None",
         # Test cases for a share that spans the Thanksgiving weekend:
         # November 2020
         # Su Mo Tu We Th Fr Sa
@@ -84,7 +84,8 @@ def test_state_next_property():
         "FIRST_EMAIL   2020-11-30  SECOND_EMAIL 2020-12-03",
         "SECOND_EMAIL  2020-12-03  FINAL_EMAIL  2020-12-04",
         "FINAL_EMAIL   2020-12-04  CLEANUP      2020-12-07",
-        "CLEANUP       2020-12-07  None         None",
+        "CLEANUP       2020-12-07  CLEANUP         None",
+        "HOLD          2020-12-07  HOLD            None",
     ],
 )
 def test_get_transition(test_case: str):

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -43,12 +43,12 @@ def test_state_ordering():
 
 
 def test_state_next_property():
-    assert state.State.INITIAL.next == state.State.FIRST_EMAIL
-    assert state.State.FIRST_EMAIL.next == state.State.SECOND_EMAIL
-    assert state.State.SECOND_EMAIL.next == state.State.FINAL_EMAIL
-    assert state.State.FINAL_EMAIL.next == state.State.CLEANUP
-    assert state.State.CLEANUP.next is None
-    assert state.State.HOLD.next is None
+    assert state.State.INITIAL.next is state.State.FIRST_EMAIL
+    assert state.State.FIRST_EMAIL.next is state.State.SECOND_EMAIL
+    assert state.State.SECOND_EMAIL.next is state.State.FINAL_EMAIL
+    assert state.State.FINAL_EMAIL.next is state.State.CLEANUP
+    assert state.State.CLEANUP.next is state.State.CLEANUP
+    assert state.State.HOLD.next is state.State.HOLD
 
 
 @mark.parametrize(
@@ -99,36 +99,16 @@ def test_get_transition(test_case: str):
     assert new_date == expect_new_date
 
 
-def test_get_next_state_initial():
-    assert state.get_next_state(state.State.INITIAL) == state.State.FIRST_EMAIL
+def test_get_state_illegal_str():
+    with raises(KeyError):
+        state.State["initial"]
 
 
-def test_get_next_state_first_email():
-    assert state.get_next_state(state.State.FIRST_EMAIL) == state.State.SECOND_EMAIL
+def test_get_state_illegal_None():
+    with raises(KeyError):
+        state.State[None]  # type: ignore
 
 
-def test_get_next_state_second_email():
-    assert state.get_next_state(state.State.SECOND_EMAIL) == state.State.FINAL_EMAIL
-
-
-def test_get_next_state_final_email():
-    assert state.get_next_state(state.State.FINAL_EMAIL) == state.State.CLEANUP
-
-
-def test_get_next_state_cleanup():
-    assert state.get_next_state(state.State.CLEANUP) is None
-
-
-def test_get_next_state_illegal_str():
-    with raises(TypeError):
-        state.get_next_state("initial")  # type: ignore
-
-
-def test_get_next_state_illegal_None():
-    with raises(TypeError):
-        state.get_next_state(None)  # type: ignore
-
-
-def test_get_next_state_illegal_false():
-    with raises(TypeError):
-        state.get_next_state(False)  # type: ignore
+def test_get_state_illegal_false():
+    with raises(KeyError):
+        state.State[False]  # type: ignore


### PR DESCRIPTION
- Restore support for Python 3.10, since not using `Self` in state
- Inline get_next_state, simplifying state.State.next
- Make state.get_transition  return simpler `tuple[State, date | None]`
- Update test code